### PR TITLE
fix: "Invlaid" to "Invalid"

### DIFF
--- a/src/eras/allegra/tx/AllegraTxOut.ts
+++ b/src/eras/allegra/tx/AllegraTxOut.ts
@@ -53,10 +53,10 @@ export class AllegraTxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'AllegraTxOut'");
+        )) throw new Error("invalid 'address' while constructing 'AllegraTxOut'");
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'AllegraTxOut'");
+        )) throw new Error("invalid 'value' while constructing 'AllegraTxOut'");
 
         this.address = address;
         this.value = value;

--- a/src/eras/alonzo/tx/AlonzoTxOut.ts
+++ b/src/eras/alonzo/tx/AlonzoTxOut.ts
@@ -62,11 +62,11 @@ export class AlonzoTxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'AlonzoTxOut'");
+        )) throw new Error("invalid 'address' while constructing 'AlonzoTxOut'");
 
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'AlonzoTxOut'");
+        )) throw new Error("invalid 'value' while constructing 'AlonzoTxOut'");
 
         this.address = address;
 

--- a/src/eras/alonzo/tx/AlonzoTxRedeemer.ts
+++ b/src/eras/alonzo/tx/AlonzoTxRedeemer.ts
@@ -101,7 +101,7 @@ export class AlonzoTxRedeemer
 
         if(!(
             canBeUInteger( index )
-        ))throw new Error("invlaid redeemer index");
+        ))throw new Error("invalid redeemer index");
         this.index = Number( forceBigUInt( index ) );
 
         if(!(

--- a/src/eras/babbage/tx/BabbageTxOut.ts
+++ b/src/eras/babbage/tx/BabbageTxOut.ts
@@ -67,11 +67,11 @@ export class BabbageTxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'BabbageTxOut'");
+        )) throw new Error("invalid 'address' while constructing 'BabbageTxOut'");
 
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'BabbageTxOut'");
+        )) throw new Error("invalid 'value' while constructing 'BabbageTxOut'");
 
         this.address = address;
 

--- a/src/eras/babbage/tx/BabbageTxRedeemer.ts
+++ b/src/eras/babbage/tx/BabbageTxRedeemer.ts
@@ -101,7 +101,7 @@ export class BabbageTxRedeemer
 
         if(!(
             canBeUInteger( index )
-        ))throw new Error("invlaid redeemer index");
+        ))throw new Error("invalid redeemer index");
         this.index = Number( forceBigUInt( index ) );
 
         if(!(

--- a/src/eras/conway/tx/ConwayTxOut.ts
+++ b/src/eras/conway/tx/ConwayTxOut.ts
@@ -67,11 +67,11 @@ export class ConwayTxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'ConwayTxOut'");
+        )) throw new Error("invalid 'address' while constructing 'ConwayTxOut'");
 
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'ConwayTxOut'");
+        )) throw new Error("invalid 'value' while constructing 'ConwayTxOut'");
 
         this.address = address;
 

--- a/src/eras/conway/tx/ConwayTxRedeemer.ts
+++ b/src/eras/conway/tx/ConwayTxRedeemer.ts
@@ -109,7 +109,7 @@ export class ConwayTxRedeemer
 
         if(!(
             canBeUInteger( index )
-        ))throw new Error("invlaid redeemer index");
+        ))throw new Error("invalid redeemer index");
         this.index = Number( forceBigUInt( index ) );
 
         if(!(

--- a/src/eras/mary/tx/MaryTxOut.ts
+++ b/src/eras/mary/tx/MaryTxOut.ts
@@ -53,10 +53,10 @@ export class MaryTxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'MaryTxOut'");
+        )) throw new Error("invalid 'address' while constructing 'MaryTxOut'");
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'MaryTxOut'");
+        )) throw new Error("invalid 'value' while constructing 'MaryTxOut'");
 
         this.address = address;
         this.value = value;

--- a/src/eras/shelley/tx/ShelleyTxOut.ts
+++ b/src/eras/shelley/tx/ShelleyTxOut.ts
@@ -53,10 +53,10 @@ export class ShelleyTxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'ShelleyTxOut'");
+        )) throw new Error("invalid 'address' while constructing 'ShelleyTxOut'");
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'ShelleyTxOut'");
+        )) throw new Error("invalid 'value' while constructing 'ShelleyTxOut'");
 
         this.address = address;
         this.value = value;

--- a/src/tx/TxWitnessSet/TxRedeemer.ts
+++ b/src/tx/TxWitnessSet/TxRedeemer.ts
@@ -108,7 +108,7 @@ export class TxRedeemer
 
         if(!(
             canBeUInteger( index )
-        ))throw new Error("invlaid redeemer index");
+        ))throw new Error("invalid redeemer index");
         this.index = Number( forceBigUInt( index ) );
 
         if(!(

--- a/src/tx/body/output/TxOut.ts
+++ b/src/tx/body/output/TxOut.ts
@@ -67,11 +67,11 @@ export class TxOut
         }
         if(!(
             address instanceof Address
-        )) throw new Error("invlaid 'address' while constructing 'TxOut'");
+        )) throw new Error("invalid 'address' while constructing 'TxOut'");
 
         if(!(
             value instanceof Value
-        )) throw new Error("invlaid 'value' while constructing 'TxOut'");
+        )) throw new Error("invalid 'value' while constructing 'TxOut'");
 
         this.address = address;
 


### PR DESCRIPTION
Just found the spelling error, in multiple locations so I just global replaced "invlaid" to "invalid". 

No breaking changes or retrocompatibility issues should arise from this 😅 