### PR TITLE
fix: AuxiliaryData.fromCborObj rejects metadata-only conway aux_data

### DIFF
--- a/src/tx/AuxiliaryData/AuxiliaryData.ts
+++ b/src/tx/AuxiliaryData/AuxiliaryData.ts
@@ -14,7 +14,7 @@ export interface IAuxiliaryData {
     nativeScripts?: (NativeScript | Script<ScriptType.NativeScript>)[];
     plutusV1Scripts?: (PlutusScriptJsonFormat<ScriptType.PlutusV1 | "PlutusScriptV1"> | Script<ScriptType.PlutusV1>)[];
     plutusV2Scripts?: (PlutusScriptJsonFormat<ScriptType.PlutusV2 | "PlutusScriptV2"> | Script<ScriptType.PlutusV2>)[];
-    plutusV3Scripts?: (PlutusScriptJsonFormat<ScriptType.PlutusV3 | "PlutusScriptV2"> | Script<ScriptType.PlutusV3>)[];
+    plutusV3Scripts?: (PlutusScriptJsonFormat<ScriptType.PlutusV3 | "PlutusScriptV3"> | Script<ScriptType.PlutusV3>)[];
 }
 
 function scriptArrToCbor( scripts: Script[] ): CborArray
@@ -247,9 +247,10 @@ export class AuxiliaryData
             cObj.data instanceof CborMap
         )) throw new InvalidCborFormatError("AuxiliaryData")
 
-        let fields: (CborObj | undefined)[] = new Array( 4 ).fill( undefined );
+        // 5 fields: 0 metadata, 1 native scripts, 2 plutus v1, 3 plutus v2, 4 plutus v3
+        let fields: (CborObj | undefined)[] = new Array( 5 ).fill( undefined );
 
-        for( let i = 0; i < 4; i++)
+        for( let i = 0; i < 5; i++)
         {
             const { v } = cObj.data.map.find(
                 ({ k }) => k instanceof CborUInt && Number( k.num ) === i
@@ -268,11 +269,13 @@ export class AuxiliaryData
             _pV3
         ] = fields;
 
+        // every field of conway aux data is optional;
+        // only validate the ones that are present (e.g. metadata-only is valid)
         if(!(
-            _native instanceof CborArray &&
-            _pV1 instanceof CborArray &&
-            _pV2 instanceof CborArray &&
-            _pV3 instanceof CborArray
+            ( _native === undefined || _native instanceof CborArray ) &&
+            ( _pV1    === undefined || _pV1    instanceof CborArray ) &&
+            ( _pV2    === undefined || _pV2    instanceof CborArray ) &&
+            ( _pV3    === undefined || _pV3    instanceof CborArray )
         ))
         throw new InvalidCborFormatError("AuxiliaryData")
 
@@ -308,7 +311,7 @@ export class AuxiliaryData
             nativeScripts: this.nativeScripts?.map( s => s.toJson() ),
             plutusV1Scripts: this.plutusV1Scripts?.map( s => s.toJson() ),
             plutusV2Scripts: this.plutusV2Scripts?.map( s => s.toJson() ),
-            plutusV3Scripts: this.plutusV2Scripts?.map( s => s.toJson() )
+            plutusV3Scripts: this.plutusV3Scripts?.map( s => s.toJson() )
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #18.

`AuxiliaryData.fromCborObj` could not decode any tag-259 (conway) auxiliary data in
practice. Two compounding bugs:

1. **All optional script fields were required.** The validation demanded that
   `native`, `pV1`, `pV2` and `pV3` are all `CborArray`s, so metadata-only
   aux_data (by far the most common on-chain shape, e.g. CIP-20/CIP-25
   transactions) threw `InvalidCborFormatError` — even though the construction
   code right below already handles each field being `undefined`.

2. **Off-by-one in the field loop.** `fields` was `new Array(4)` with a loop
   bound of `i < 4`, so only keys 0–3 (metadata, native, plutus v1, plutus v2)
   were ever read. Key 4 (plutus v3 scripts) was silently dropped, and the
   destructured `_pV3` was *always* `undefined` — which also means the strict
   check in (1) failed for **every** tag-259 input, not just metadata-only ones.

### Changes

- `fields` covers all 5 conway aux_data keys (0–4), so plutus v3 scripts at
  key 4 are parsed.
- The validation now only checks fields that are present: each script field
  must be a `CborArray` *if it exists*; absent fields are fine (matching the
  conway CDDL, where every field of `auxiliary_data` is optional).
- Two adjacent copy-paste fixes in the same class: `toJson()` returned
  `plutusV2Scripts` under the `plutusV3Scripts` key, and the
  `IAuxiliaryData.plutusV3Scripts` type referenced the `"PlutusScriptV2"`
  literal.