### PR TITLE
fix: repoint cardano-ledger-ts aux_data/body imports to eras/common (dual-class instanceof)

### DIFF
--- a/src/tx/AuxiliaryData/AuxiliaryData.ts
+++ b/src/tx/AuxiliaryData/AuxiliaryData.ts
@@ -5,7 +5,7 @@ import { AuxiliaryDataHash } from "../../hashes";
 import { NativeScript, nativeScriptFromCborObj } from "../../script/NativeScript";
 import { PlutusScriptJsonFormat, Script, ScriptType } from "../../script/Script";
 import { ToJson } from "../../utils/ToJson";
-import { TxMetadata } from "../metadata/TxMetadata";
+import { TxMetadata } from "../../eras/common/tx/metadata/TxMetadata";
 import { InvalidCborFormatError } from "../../utils/InvalidCborFormatError";
 import { getSubCborRef, subCborRefOrUndef } from "../../utils/getSubCborRef";
 


### PR DESCRIPTION
## Problem
In `@harmoniclabs/cardano-ledger-ts@0.5.1`, `AuxiliaryData.js` imported the divergent `dist/tx/metadata/TxMetadata` copy, while the package index — and therefore TxBuilder's `memo`/metadata construction — uses the `eras/common` copy. As a result, `metadata instanceof TxMetadata` **always** failed → every metadata/memo build threw.

## Fix
Repoint the `TxMetadata` import in `src/tx/AuxiliaryData/AuxiliaryData.ts` to the `eras/common` copy (the same one the package index / TxBuilder uses) so `instanceof` matches.