### PR TITLE
fix: totCollateral guard missing its throw so valid values were silently dropped

### DIFF
--- a/src/eras/babbage/tx/BabbageTxBody.ts
+++ b/src/eras/babbage/tx/BabbageTxBody.ts
@@ -318,7 +318,7 @@ export class BabbageTxBody
         if(!(
             totCollateral === undefined ||
             canBeUInteger( totCollateral )
-        ))
+        )) throw new Error("invalid 'totCollateral' field");
 
         this.totCollateral = maybeBigUint( totCollateral );
 

--- a/src/eras/conway/tx/ConwayTxBody.ts
+++ b/src/eras/conway/tx/ConwayTxBody.ts
@@ -350,7 +350,7 @@ export class ConwayTxBody
         if(!(
             totCollateral === undefined ||
             canBeUInteger( totCollateral )
-        ))
+        )) throw new Error("invalid 'totCollateral' field");
 
         this.totCollateral = maybeBigUint( totCollateral );
 

--- a/src/eras/dijkstra/tx/DijkstraTxBody.ts
+++ b/src/eras/dijkstra/tx/DijkstraTxBody.ts
@@ -358,7 +358,7 @@ export class DijkstraTxBody
         if(!(
             totCollateral === undefined ||
             canBeUInteger( totCollateral )
-        ))
+        )) throw new Error("invalid 'totCollateral' field");
 
         this.totCollateral = maybeBigUint( totCollateral );
 

--- a/src/tx/body/TxBody.ts
+++ b/src/tx/body/TxBody.ts
@@ -356,7 +356,7 @@ export class TxBody
         if(!(
             totCollateral === undefined ||
             canBeUInteger( totCollateral )
-        ))
+        )) throw new Error("invalid 'totCollateral' field");
 
         this.totCollateral = maybeBigUint( totCollateral );
 

--- a/src/tx/body/__tests__/TxBody.totCollateral.test.ts
+++ b/src/tx/body/__tests__/TxBody.totCollateral.test.ts
@@ -1,0 +1,45 @@
+import { TxBody } from "../TxBody";
+import { UTxO } from "../output/UTxO";
+import { TxOut } from "../output/TxOut";
+import { Address } from "../../../eras/common/ledger/Address";
+import { Value } from "../../../eras/common/ledger/Value/Value";
+
+// Regression for the inverted `totCollateral` guard: the validation `if(!(...))` was missing its
+// `throw`, so the assignment below became the if-body — a VALID totCollateral was silently dropped
+// (body field 17 never serialized; parse → reconstruct round-trips lost the field and changed the
+// body hash), while only INVALID input was ever assigned.
+describe("TxBody totCollateral", () => {
+    const addr = Address.fromString(
+        "addr_test1qqetxfc069tpemq25f954mrg2rxsr9jgvqe78hvyn9zuxxdvaqvlg96unszfywdfrjwq0m8zp0m7wjza0n2pfeep5h7qw62gd8"
+    );
+    const utxo = new UTxO({
+        utxoRef: { id: "aa".repeat(32), index: 0 },
+        resolved: { address: addr, value: Value.lovelaces(10_000_000) },
+    });
+    const base = {
+        inputs: [utxo] as [UTxO],
+        outputs: [new TxOut({ address: addr, value: Value.lovelaces(9_000_000) })],
+        fee: 200_000,
+    };
+
+    test("a valid totCollateral is kept (was silently dropped)", () => {
+        const body = new TxBody({ ...base, totCollateral: 5_000_000 });
+        expect(body.totCollateral).toBe(BigInt(5_000_000));
+    });
+
+    test("totCollateral survives a CBOR round-trip (field 17)", () => {
+        const body = new TxBody({ ...base, totCollateral: 5_000_000 });
+        const reparsed = TxBody.fromCbor(body.toCbor());
+        expect(reparsed.totCollateral).toBe(BigInt(5_000_000));
+    });
+
+    test("undefined stays undefined", () => {
+        expect(new TxBody({ ...base }).totCollateral).toBeUndefined();
+    });
+
+    test("an invalid totCollateral throws (was the only case that ever got assigned)", () => {
+        expect(
+            () => new TxBody({ ...base, totCollateral: -1 as unknown as number })
+        ).toThrow("totCollateral");
+    });
+});


### PR DESCRIPTION
###  Summary

fix: totCollateral guard missing its throw; valid values were silently dropped

The totCollateral validation `if(!(...))` in the TxBody constructors was
missing its throw statement, so the assignment below became the if-body:
a VALID totCollateral was never assigned (body field 17 silently omitted
on serialization; parse -> reconstruct round-trips lost the field and
changed the body hash), while only INVALID input was ever assigned.

This PR adds the missing throw matching the idiom of every neighboring field
guard (collateralReturn, refInputs, ...) in all four copies, plus a
regression test covering keep/round-trip/undefined/invalid.

### Bug

The `totCollateral` validation in the `TxBody` constructors is missing its `throw`, so the
assignment below binds to the `if` and only runs for **invalid** input:

```ts
if(!(
    totCollateral === undefined ||
    canBeUInteger( totCollateral )
))
                                                  // <- throw missing here
this.totCollateral = maybeBigUint( totCollateral );
```

Every neighboring field guard in the same constructor (`collateralReturn`, `refInputs`, …) follows
the `if(!(...)) throw new Error(...)` idiom, but this one lost its `throw`, which is inverting the semantics:

- a **valid** `totCollateral` is silently dropped → body field 17 (`total_collateral`) is never
  serialized, so the transaction loses the collateral-forfeiture bound its author set;
- `fromCborObj` routes parsed bodies through this constructor, so a parse → reconstruct round-trip
  **loses the field and changes the body hash**
- an **invalid** value is the only thing that ever gets assigned.

The era refactor created four copies of the bug (main + Babbage/Conway/Dijkstra `TxBody`).

### Fix

Insert the missing `throw`, exactly matching the file's idiom, in all four constructors.

```ts
if(!(
    totCollateral === undefined ||
    canBeUInteger( totCollateral )
)) throw new Error("invalid 'totCollateral' field");

this.totCollateral = maybeBigUint( totCollateral );
```

### Tests

New `src/tx/body/__tests__/TxBody.totCollateral.test.ts`:

- a valid `totCollateral` is kept (previously `undefined`);
- the field survives a CBOR round-trip (field 17 present);
- `undefined` stays `undefined`;
- invalid input throws (previously it was the only case that got assigned).

